### PR TITLE
Add GasRoute Oracle Agent to fetch multi-chain gas prices

### DIFF
--- a/src/gasroute_oracle/agent.js
+++ b/src/gasroute_oracle/agent.js
@@ -1,0 +1,44 @@
+// GasRoute Oracle Agent Implementation
+
+const { Agent } = require('@lucid-dreams/agent-kit');
+const axios = require('axios');
+
+class GasRouteOracleAgent extends Agent {
+  constructor(config) {
+    super(config);
+    this.apiBaseUrl = config.apiBaseUrl || 'https://api.gasprice.io';
+    this.chainIds = config.chainIds || ['1', '56', '137']; // Default to Ethereum, Binance Smart Chain, Polygon
+  }
+
+  async getGasPrice(chainId) {
+    try {
+      const response = await axios.get(`${this.apiBaseUrl}/gas-price/${chainId}`);
+      return response.data.gasPrice;
+    } catch (error) {
+      console.error(`Error fetching gas price for chain ${chainId}:`, error);
+      return null;
+    }
+  }
+
+  async getMultiChainGasPrices() {
+    const gasPrices = {};
+    for (let chainId of this.chainIds) {
+      const price = await this.getGasPrice(chainId);
+      if (price !== null) {
+        gasPrices[chainId] = price;
+      }
+    }
+    return gasPrices;
+  }
+
+  async run() {
+    try {
+      const gasPrices = await this.getMultiChainGasPrices();
+      this.emit('gasPrices', gasPrices);
+    } catch (error) {
+      console.error('Error fetching multi-chain gas prices:', error);
+    }
+  }
+}
+
+module.exports = GasRouteOracleAgent;

--- a/src/gasroute_oracle/index.js
+++ b/src/gasroute_oracle/index.js
@@ -1,0 +1,16 @@
+// GasRoute Oracle Agent Entry Point
+
+const GasRouteOracleAgent = require('./agent');
+
+const agentConfig = {
+  apiBaseUrl: 'https://api.gasprice.io',
+  chainIds: ['1', '56', '137'] // Ethereum, Binance Smart Chain, Polygon
+};
+
+const gasRouteAgent = new GasRouteOracleAgent(agentConfig);
+
+gasRouteAgent.on('gasPrices', (gasPrices) => {
+  console.log('Fetched multi-chain gas prices:', gasPrices);
+});
+
+gasRouteAgent.run();


### PR DESCRIPTION
I added a GasRoute Oracle Agent using @lucid-dreams/agent-kit that fetches multi-chain gas prices and emits them. The agent pulls gas price data from the API at https://api.gasprice.io, and currently supports Ethereum, Binance Smart Chain, and Polygon. I’ve added the agent to a new 'src/gasroute_oracle' directory with a separate entry point file to keep things organized.

This change will help in monitoring gas prices across multiple blockchains in a more unified way, making it easier to fetch current data for various chains. The agent simplifies the process of tracking and comparing gas prices for developers working with Ethereum, Binance Smart Chain, or Polygon.

The agent has been structured to be easily extendable in case we need to support additional blockchains in the future. The multi-chain support is important for projects that interact with different ecosystems, and by fetching data from an API, it ensures that the data remains up-to-date. I also included basic error handling to ensure the agent remains solid.

Closes #4