### PR TITLE
Add Approval Risk Auditor submission

### DIFF
--- a/submissions/approval-risk-auditor-douglance.md
+++ b/submissions/approval-risk-auditor-douglance.md
@@ -29,6 +29,7 @@ POST /entrypoints/audit-approvals/invoke
   "wallet": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
   "chains": ["ethereum", "base"],
   "token_addresses": [],
+  "nft_addresses": [],
   "stale_days": 180
 }
 ```
@@ -45,6 +46,7 @@ The agent returns:
 Revocation data is unsigned transaction calldata:
 
 - ERC-20: `approve(spender, 0)`
+- ERC-721 single-token approvals: `approve(address(0), tokenId)`
 - ERC-721/ERC-1155 operator approvals: `setApprovalForAll(operator, false)`
 
 ## x402 Reachability
@@ -55,7 +57,7 @@ Unauthenticated invocation returns the expected x402 payment challenge:
 curl -i -X POST \
   https://approval-risk-auditor.doug-lance.workers.dev/entrypoints/audit-approvals/invoke \
   -H 'content-type: application/json' \
-  -d '{"input":{"wallet":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","chains":["ethereum"],"token_addresses":[],"stale_days":180}}'
+  -d '{"input":{"wallet":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","chains":["ethereum"],"token_addresses":[],"nft_addresses":[],"stale_days":180}}'
 ```
 
 Expected response: HTTP `402` with `X-PAYMENT header is required` and an
@@ -66,7 +68,7 @@ Expected response: HTTP `402` with `X-PAYMENT header is required` and an
 - [x] Matches Etherscan-style approval log data for configured top tokens.
 - [x] Identifies unlimited ERC-20 approvals.
 - [x] Identifies stale approvals using `stale_days`.
-- [x] Identifies NFT/operator approvals.
+- [x] Identifies ERC-721 single-token and NFT/operator approvals.
 - [x] Provides valid unsigned revocation transaction data.
 - [x] Deployed on a public HTTPS domain.
 - [x] Reachable via x402.

--- a/submissions/approval-risk-auditor-douglance.md
+++ b/submissions/approval-risk-auditor-douglance.md
@@ -13,6 +13,9 @@ https://approval-risk-auditor.doug-lance.workers.dev
 Agent manifest:
 https://approval-risk-auditor.doug-lance.workers.dev/.well-known/agent.json
 
+Source:
+https://github.com/douglance/approval-risk-auditor
+
 Entrypoint:
 
 ```text

--- a/submissions/approval-risk-auditor-douglance.md
+++ b/submissions/approval-risk-auditor-douglance.md
@@ -1,0 +1,96 @@
+# Approval Risk Auditor
+
+Related issue: https://github.com/daydreamsai/agent-bounties/issues/5
+
+## Agent
+
+Approval Risk Auditor scans EVM wallets for ERC-20 and NFT/operator approvals,
+flags risky approvals, and returns unsigned revocation transaction data.
+
+Live deployment:
+https://approval-risk-auditor.doug-lance.workers.dev
+
+Agent manifest:
+https://approval-risk-auditor.doug-lance.workers.dev/.well-known/agent.json
+
+Entrypoint:
+
+```text
+POST /entrypoints/audit-approvals/invoke
+```
+
+## Inputs
+
+```json
+{
+  "wallet": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+  "chains": ["ethereum", "base"],
+  "token_addresses": [],
+  "stale_days": 180
+}
+```
+
+## Outputs
+
+The agent returns:
+
+- `approvals[]`
+- `risk_flags[]`
+- `revoke_tx_data[]`
+- `summary`
+
+Revocation data is unsigned transaction calldata:
+
+- ERC-20: `approve(spender, 0)`
+- ERC-721/ERC-1155 operator approvals: `setApprovalForAll(operator, false)`
+
+## x402 Reachability
+
+Unauthenticated invocation returns the expected x402 payment challenge:
+
+```bash
+curl -i -X POST \
+  https://approval-risk-auditor.doug-lance.workers.dev/entrypoints/audit-approvals/invoke \
+  -H 'content-type: application/json' \
+  -d '{"input":{"wallet":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","chains":["ethereum"],"token_addresses":[],"stale_days":180}}'
+```
+
+Expected response: HTTP `402` with `X-PAYMENT header is required` and an
+`accepts[]` payment requirement for `base-sepolia`.
+
+## Acceptance Criteria
+
+- [x] Matches Etherscan-style approval log data for configured top tokens.
+- [x] Identifies unlimited ERC-20 approvals.
+- [x] Identifies stale approvals using `stale_days`.
+- [x] Identifies NFT/operator approvals.
+- [x] Provides valid unsigned revocation transaction data.
+- [x] Deployed on a public HTTPS domain.
+- [x] Reachable via x402.
+
+## Validation
+
+Local implementation checks:
+
+```bash
+npm run build
+npm test
+npm audit --audit-level=moderate
+wrangler deploy --dry-run
+```
+
+Public endpoint checks:
+
+```bash
+curl -fsS https://approval-risk-auditor.doug-lance.workers.dev/health
+curl -fsS https://approval-risk-auditor.doug-lance.workers.dev/.well-known/agent.json
+curl -fsS https://approval-risk-auditor.doug-lance.workers.dev/entrypoints
+```
+
+## Payment Wallet
+
+Solana wallet:
+
+```text
+EGNeDwAojepsbw4BTMXSERwYm3poirWQGfXEUh8yWofX
+```


### PR DESCRIPTION
## Bounty Submission

**Related Issue:** #5

---

## Submission File

**File Path:** `submissions/approval-risk-auditor-douglance.md`

---

## Agent Description

Approval Risk Auditor scans EVM wallets for ERC-20 and NFT/operator approvals, flags unlimited/stale/operator approvals, and returns unsigned revoke transaction calldata for `approve(spender, 0)` and `setApprovalForAll(operator, false)`.

---

## Live Link

**Deployment URL:** https://approval-risk-auditor.doug-lance.workers.dev

Manifest: https://approval-risk-auditor.doug-lance.workers.dev/.well-known/agent.json

---

## Acceptance Criteria

- [x] Meets all technical specifications
- [x] Deployed on a domain
- [x] Reachable via x402
- [x] All acceptance criteria from the issue are met
- [x] Submission file added to `submissions/` directory

---

## Other Resources

- **Repository:** https://github.com/douglance/approval-risk-auditor
- **x402 proof:** unauthenticated `POST /entrypoints/audit-approvals/invoke` returns HTTP 402 with `X-PAYMENT header is required` and `accepts[]` for `base-sepolia`.
- **Entrypoint:** `POST /entrypoints/audit-approvals/invoke`
- **Public discovery:** `/health`, `/entrypoints`, and `/.well-known/agent.json`

---

## Solana Wallet

**Wallet Address:** `EGNeDwAojepsbw4BTMXSERwYm3poirWQGfXEUh8yWofX`

---

## Additional Notes

The agent uses `@lucid-dreams/agent-kit` with x402 payments enabled. It scans Etherscan-compatible approval logs for configured top tokens and optional caller-supplied token addresses, classifies risks, and emits unsigned revoke transaction data only. It does not request or handle private keys.
