### PR TITLE
feat: LP IL Estimator — impermanent loss + fee APR via DeFiLlama (bounty #7)

### DIFF
--- a/submissions/lp-il-estimator.md
+++ b/submissions/lp-il-estimator.md
@@ -1,0 +1,62 @@
+# LP Impermanent Loss Estimator — Submission
+
+**Closes #7**
+
+## Agent URL
+
+https://lp-il-estimator.netlify.app
+
+## Description
+
+Computes impermanent loss and fee APR for any LP position using live and historical token prices from DeFiLlama. Supports Uniswap v2/v3, Curve, Balancer.
+
+## Features
+
+- **Pool lookup** by on-chain address via DeFiLlama yields API
+- **Token prices** now and at entry (window_hours ago) via `coins.llama.fi`
+- **IL calculation**: constant-product formula using actual deposit amounts
+  - `lp_value_now` vs `hodl_value_now` → IL%
+  - Notes if Uniswap v3 concentrated liquidity detected (formula is lower bound)
+- **fee_apr_est**: from DeFiLlama's `apyBase` (fee component only, no rewards)
+- **volume_window**: trading volume scaled to the requested window
+
+## Entrypoint
+
+`POST /entrypoints/estimate/invoke`
+
+```json
+{
+  "pool_address": "0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8",
+  "token_weights": [50, 50],
+  "deposit_amounts": ["1000", "0.5"],
+  "window_hours": 24,
+  "chain": "ethereum"
+}
+```
+
+## Returns
+
+```json
+{
+  "IL_percent": -2.35,
+  "fee_apr_est": 5.2,
+  "volume_window": 12345678,
+  "lp_value_now": 2890.50,
+  "hodl_value_now": 2959.12,
+  "notes": ["Uniswap v3 detected: IL is amplified..."]
+}
+```
+
+## x402 Payment
+
+Requires x402 payment header on base-sepolia.
+
+## Stack
+
+- `@lucid-dreams/agent-kit` + Netlify Functions v2
+- DeFiLlama Yields + Coins APIs (free, no auth)
+- TypeScript
+
+## Solana Wallet
+
+`BVf9eNCQFSamVQ2VwkQZ9UvkUX37j7Syk75DvZtutJef`


### PR DESCRIPTION
## LP Impermanent Loss Estimator

**Closes #7**

Computes IL% and fee APR for any LP position using live and historical prices from DeFiLlama.

### Live URL
https://lp-il-estimator.netlify.app

### Entrypoint
`POST /entrypoints/estimate/invoke`

```json
{
  "pool_address": "0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8",
  "token_weights": [50, 50],
  "deposit_amounts": ["1000", "0.5"],
  "window_hours": 24,
  "chain": "ethereum"
}
```

### Returns
- `IL_percent` — impermanent loss vs HODL (negative = loss)
- `fee_apr_est` — estimated APR from fees (DeFiLlama apyBase)
- `volume_window` — trading volume over the requested window
- `lp_value_now` vs `hodl_value_now` — dollar amounts
- `notes` — warnings (Uniswap v3 concentration, multi-token)

### IL Calculation
Constant-product AMM formula using deposit amounts and historical prices:
- `k = amount0 * amount1`
- `lp_amount0_now = sqrt(k * p1_now / p0_now)`
- `IL = (lp_value - hodl_value) / hodl_value * 100`

### Stack
- `@lucid-dreams/agent-kit` + Netlify Functions v2 + x402 paywall
- DeFiLlama Yields API + `coins.llama.fi` historical prices (free, no API key)
- TypeScript

### Solana Wallet
`BVf9eNCQFSamVQ2VwkQZ9UvkUX37j7Syk75DvZtutJef`