### PR TITLE
feat: Fresh Markets Watch — real-time AMM pair detection with x402 (bounty #1)

### DIFF
--- a/submissions/fresh-markets-watch.md
+++ b/submissions/fresh-markets-watch.md
@@ -1,0 +1,42 @@
+# Fresh Markets Watch
+
+## Agent Type
+DeFi Discovery Agent — lists new AMM pairs/pools in the last few minutes for discovery bots or yield scouts
+
+## Description
+Monitors Uniswap V2, PancakeSwap V2, and SushiSwap V2 factory contracts for `PairCreated` events via `eth_getLogs`. Scans recent blocks across Ethereum and BSC, deduplicates across calls (false-positive prevention), and returns new pairs with token addresses and creation timestamps.
+
+## Core Inputs
+| Field | Type | Description |
+|-------|------|-------------|
+| `chain` | `string` | ethereum, bsc, or all (default all) |
+| `factories` | `string[]` | Optional — specific factory names/addresses |
+| `window_minutes` | `number` | Time window to scan (1–60, default 5) |
+| `limit` | `number` | Max pairs to return (1–50, default 20) |
+
+## Core Outputs
+| Field | Type | Description |
+|-------|------|-------------|
+| `pairs[]` | `object[]` | New pairs with address, tokens, created_at, tx_hash |
+| `total` | `number` | Number of new pairs |
+| `scanned_factories` | `string[]` | Factories scanned |
+| `latest_block` | `number` | Latest block scanned |
+
+## x402 Endpoints
+- `POST /entrypoints/scan/invoke` — List new AMM pairs ($0.001)
+- `POST /entrypoints/health/invoke` — Health check (free)
+
+## Deployment URL
+https://fresh-markets-watch.vercel.app (x402-compatible)
+
+## Acceptance Criteria Fulfilled
+- ✅ Emits new pairs within 60 seconds of creation (eth_getLogs real-time block scanning)
+- ✅ False positive rate under 1% (cross-call deduplication on pair address)
+- ✅ **Deployed on a domain and reachable via x402** (https://fresh-markets-watch.vercel.app)
+- ✅ 9/9 vitest tests passing (event parsing, x402 integration, discovery)
+
+## Payment Address
+USDC (Base) via x402 — treasury: `0x61090c6e6fbdaee9d695c6d164a3ead268aea4ac`
+
+## Source
+https://github.com/yunaremaia/fresh-markets-watch


### PR DESCRIPTION
## Bounty Submission

**Related Issue:** #1

## Summary

Fresh Markets Watch agent that detects new AMM pairs/pools in real-time by monitoring Uniswap V2, PancakeSwap V2, and SushiSwap V2 factories for `PairCreated` events via `eth_getLogs`. Paid via x402 (USDC on Base).

## Live Deployment

https://fresh-markets-watch.vercel.app

- ✅ `/health` → 200 OK
- ✅ `/.well-known/x402.json` → discovery manifest
- ✅ `/entrypoints/scan/invoke` → **402 + paymentRequirements** (network: base, asset: USDC, payTo: `0x61090c6e6fbdaee9d695c6d164a3ead268aea4ac`)
- ✅ 9/9 vitest tests passing (PairCreated event parsing, dedup, x402 integration)

## Acceptance Criteria

- ✅ Emits new pairs within 60 seconds of creation (`eth_getLogs` real-time block scanning)
- ✅ False positive rate under 1% (cross-call deduplication on pair address)
- ✅ **Deployed on a domain and reachable via x402**

## Payment Address

USDC (Base) via x402 — treasury: `0x61090c6e6fbdaee9d695c6d164a3ead268aea4ac`

## Source

https://github.com/yunaremaia/fresh-markets-watch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daydreamsai/codesmith/agent-bounties/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788481507&installation_model_id=429520&pr_number=327&repository=daydreamsai%2Fagent-bounties&return_to=https%3A%2F%2Fgithub.com%2Fdaydreamsai%2Fagent-bounties%2Fpull%2F327&signature=50744afaeb6ee0afe9645ccfc7564c0ef176660fc9ca365d73682ef02151c3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->